### PR TITLE
Livewire: Writing Tests for Chirps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Livewire is a full-stack framework for Laravel that makes building dynamic inter
 
 ## Practice Scenarios
 
-- [#1: Building *Chirps* with Livewire](https://github.com/TammyTee/lara-php-practice/pull/1)
+[#1: Building *Chirps* with Livewire](https://github.com/TammyTee/lara-php-practice/pull/1)
+
+[#2: Testing the *Chirps* component](https://github.com/TammyTee/lara-php-practice/pull/2)
 
 ## Helpful Resources
 

--- a/database/factories/ChirpFactory.php
+++ b/database/factories/ChirpFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ChirpFactory extends Factory
+{
+    public function definition()
+    {
+        return [
+            'message' => $this->faker->sentence,
+        ];
+    }
+}

--- a/tests/Feature/ChirpsTest.php
+++ b/tests/Feature/ChirpsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Livewire\Chirps;
+use App\Models\Chirp;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ChirpsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function chirps_view_contains_livewire_component()
+    {
+        // test component presence
+        $this->actingAs(User::factory()->create());
+
+        $this->get(route('chirps'))->assertSeeLivewire(Chirps::class);
+    }
+
+    /** @test */
+    public function can_create_a_chirp()
+    {
+        $this->actingAs(User::factory()->create());
+
+        Livewire::test(Chirps::class)
+            ->set('chirp.message', 'Hello world!')
+            ->call('saveChirp');
+
+        $this->assertTrue(Chirp::whereMessage('Hello world!')->exists());
+    }
+
+    /** @test */
+    public function can_delete_a_chirp()
+    {
+        $this->actingAs($user = User::factory()->create());
+
+        Livewire::test(Chirps::class)
+            ->call('deleteChirp', Chirp::factory()->for($user)->create(['message' => 'Goodbye world!']));
+
+        $this->assertFalse(Chirp::whereMessage('Goodbye world!')->exists());
+    }
+
+    /** @test */
+    public function chirp_message_is_required()
+    {
+        $this->actingAs(User::factory()->create());
+
+        Livewire::test(Chirps::class)
+            ->set('chirp.message')
+            ->call('saveChirp')
+            ->assertHasErrors(['chirp.message' => 'required']);
+    }
+
+    /** @test */
+    public function chirp_message_should_be_a_string()
+    {
+        $this->actingAs(User::factory()->create());
+
+        Livewire::test(Chirps::class)
+            ->set('chirp.message', 12345)
+            ->call('saveChirp')
+            ->assertHasErrors(['chirp.message' => 'string']);
+    }
+}

--- a/tests/Feature/ChirpsTest.php
+++ b/tests/Feature/ChirpsTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature;
 use App\Http\Livewire\Chirps;
 use App\Models\Chirp;
 use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -25,9 +27,8 @@ class ChirpsTest extends TestCase
     /** @test */
     public function can_create_a_chirp()
     {
-        $this->actingAs(User::factory()->create());
-
-        Livewire::test(Chirps::class)
+        Livewire::actingAs(User::factory()->create())
+            ->test(Chirps::class)
             ->set('chirp.message', 'Hello world!')
             ->call('saveChirp');
 
@@ -37,9 +38,8 @@ class ChirpsTest extends TestCase
     /** @test */
     public function can_delete_a_chirp()
     {
-        $this->actingAs($user = User::factory()->create());
-
-        Livewire::test(Chirps::class)
+        Livewire::actingAs($user = User::factory()->create())
+            ->test(Chirps::class)
             ->call('deleteChirp', Chirp::factory()->for($user)->create(['message' => 'Goodbye world!']));
 
         $this->assertFalse(Chirp::whereMessage('Goodbye world!')->exists());
@@ -48,9 +48,8 @@ class ChirpsTest extends TestCase
     /** @test */
     public function chirp_message_is_required()
     {
-        $this->actingAs(User::factory()->create());
-
-        Livewire::test(Chirps::class)
+        Livewire::actingAs(User::factory()->create())
+            ->test(Chirps::class)
             ->set('chirp.message')
             ->call('saveChirp')
             ->assertHasErrors(['chirp.message' => 'required']);
@@ -59,11 +58,35 @@ class ChirpsTest extends TestCase
     /** @test */
     public function chirp_message_should_be_a_string()
     {
-        $this->actingAs(User::factory()->create());
-
-        Livewire::test(Chirps::class)
+        Livewire::actingAs(User::factory()->create())
+            ->test(Chirps::class)
             ->set('chirp.message', 12345)
             ->call('saveChirp')
             ->assertHasErrors(['chirp.message' => 'string']);
+    }
+
+    /** @test */
+    public function can_list_chirps()
+    {
+        Carbon::setTestNow();
+
+        $this->actingAs($user = User::factory()->create());
+
+        Chirp::factory()->for($user)
+            ->count(3)
+            ->state(new Sequence(
+                ['message' => 'Hello A', 'created_at' => now()->subDay()],
+                ['message' => 'Hello B', 'created_at' => now()->subHour()],
+                ['message' => 'Hello C', 'created_at' => now()],
+            ))
+            ->create();
+
+        Livewire::test(Chirps::class)
+            ->assertViewHas('chirps')
+            ->assertSeeInOrder([
+                'Hello C',
+                'Hello B',
+                'Hello A',
+            ]);
     }
 }


### PR DESCRIPTION
## Summary

This practice scenario tests the presence of a livewire component and the presence of its data using [Livewire's testing tools](https://laravel-livewire.com/docs/2.x/testing).

## Assertions

**Testing component presence**

```php
/** @test */
public function chirps_view_contains_livewire_component()
{
    // ...

    $this->get(route('chirps'))->assertSeeLivewire(Chirps::class);
}
```

**Testing the properties of the `Chirp` model are validated before it's saved**

```php
/** @test */
public function chirp_message_is_required()
{
    // set the auth user
    Livewire::actingAs(User::factory()->create())

         // the component to test
         ->test(Chirps::class)

         // set the value of the chirp's message property, in this case, it's null
         ->set('chirp.message')

         // call the class method to save the chirp
         ->call('saveChirp')

         // assert a validation error is present since the required data is missing
         ->assertHasErrors(['chirp.message' => 'required']);
}
```

**Testing the presence of expected elements in the view**

```php
/** @test */
public function can_list_chirps()
{
    Carbon::setTestNow();

    $this->actingAs($user = User::factory()->create());

    // create 3 existing chirps
    Chirp::factory()->for($user)
        ->count(3)
        ->state(new Sequence(
            ['message' => 'Hello A', 'created_at' => now()->subDay()],
            ['message' => 'Hello B', 'created_at' => now()->subHour()],
            ['message' => 'Hello C', 'created_at' => now()],
        ))
        ->create();

    Livewire::test(Chirps::class)

        // assert the view, chirps.blade.php, is passed data with a key of "chirps"
        ->assertViewHas('chirps')

        // assert the chirps are listed in descending order based on their created_at attribute
        ->assertSeeInOrder([
            'Hello C',
            'Hello B',
            'Hello A',
        ]);
}
```


