### PR TITLE
Tid Bits: Squashing Migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Laravel Tid Bits covers random topics or concepts I've come across in the wild v
 
 ## Practice Scenarios
 
-> *Check Back Later*
+1. [Squashing Migrations in Laravel](https://github.com/TammyTee/lara-php-practice/pull/3)
 
 ## Helpful Resources
 
 A list of helpful resources for learning Laravel Livewire
 
 1. [StackHawk - Laravel Content Security Policy](https://www.stackhawk.com/blog/laravel-content-security-policy-guide-what-it-is-and-how-to-enable-it/)
+1. [Laracasts - What's new in Laravel 8](https://laracasts.com/series/whats-new-in-laravel-8/episodes/3)
+1. [Database: Migrations - Laravel Documentation](https://laravel.com/docs/9.x/migrations#squashing-migrations)


### PR DESCRIPTION
## Summary

Laravel 8 introduced the `schema:dump` command which allows you to squash all of the existing migrations in your project down to a single database schema file. This is especially useful for longstanding projects that have a large number of migrations in their `database/migrations/` directory.

### Usage
> ⚠️ Only available for MySQL, PostgreSQL, and SQLite databases

Running the `schema:dump` command will create a new schema dump file that is placed inside a new `database/schema/` directory.

| Command | Action |
| - | - |
| `schema:dump` | Creates a new schema dump from the project's existing migration files |
| `schema:dump --prune` | Deletes the migration files that the schema dump is created from |


Any new migrations created after a dump is created will build atop the schema file when migrations are run: 
**_schema files_** ➡️ _**migrations**_

### Benefits
1. speed up your test suite
2. clean up your migrations directory